### PR TITLE
Better way to count cycles

### DIFF
--- a/libdnes/source/cpu/mos6502.d
+++ b/libdnes/source/cpu/mos6502.d
@@ -268,28 +268,31 @@ class MOS6502
         switch (opcode)
         {
             case 0x69: // Immediate
-                this.cycle += 2;
+                this.cycles += 2;
                 break;
             case 0x65: // ZeroPage
-                this.cycle += 3;
+                this.cycles += 3;
                 break;
             case 0x6D: // Absolute
             case 0x75: // ZeroPage,X
-                this.cycle += 4;
+                this.cycles += 4;
+                break;
             case 0x7D: // Absolute,X
             case 0x79: // Absolute,Y
-                this.cycle += 4;
+                this.cycles += 4;
                 if (bPageBoundaryCrossed) 
-                    this.cycle++;
+                    this.cycles++;
                 break;
             case 0x61: // Indirect,X
-                this.cycle += 6;
+                this.cycles += 6;
                 break;
             case 0x71: // Indirect,Y
-                this.cycle += 5;
+                this.cycles += 5;
                 if (bPageBoundaryCrossed) 
-                    this.cycle++;
+                    this.cycles++;
                 break;
+            default:
+                throw new Exception("Invalid opcode [ADC], cannot determine cycle count");
         }
     }
     unittest

--- a/libdnes/source/cpu/mos6502.d
+++ b/libdnes/source/cpu/mos6502.d
@@ -251,12 +251,16 @@ class MOS6502
             this.status.c = 0;
         }
 
-        if (this.a == 0) 
+        if (this.a == 0)
             this.status.z = 1;
-        
+        else
+            this.status.z = 0;
+
         if ((this.a & 0b1000_0000) == 0b1000_0000) 
             this.status.n = 1; 
-        
+        else
+            this.status.n = 0;
+
         if (((this.a^m) & 0x80) == 0 && ((a^this.a) & 0x80) != 0)
         {
             this.status.v = 1;

--- a/libdnes/source/cpu/mos6502.d
+++ b/libdnes/source/cpu/mos6502.d
@@ -248,6 +248,7 @@ class MOS6502
         else
         {
             this.a += cast(ubyte)(result);
+            this.status.c = 0;
         }
 
         if (this.a == 0) 

--- a/libdnes/source/cpu/mos6502.d
+++ b/libdnes/source/cpu/mos6502.d
@@ -213,33 +213,84 @@ class MOS6502
     private void ADC(ubyte opcode)
     {
         auto addressModeFunction = decodeAddressMode("ADC", opcode);
-        ushort finalAddress = 0;
-        ubyte valueToAdd = 0;
+        bool bPageBoundaryCrossed = false;
         auto ram = Console.ram;
 
-        if (addressModeFunction == &absoluteAddressMode)
+        ushort a; // a = accumulator value
+        ushort m; // m = operand
+        ushort c; // c = carry value
+
+        a = this.a;
+        c = this.status.c;
+
+        if (addressModeFunction == &(immediateAddressMode)) 
         {
-            this.cycles += 3;
+            m = addressModeFunction();
         }
-        else if (addressModeFunction == &indirectAddressMode)
+        else
         {
-            this.cycles += 5;
+            ushort resolvedAddress = addressModeFunction();
+            if ((resolvedAddress & 0x00FF)  == 0x00FF) 
+            {
+                bPageBoundaryCrossed = true;
+            }
+            m = ram.read(resolvedAddress);
         }
-        finalAddress = addressModeFunction();
-        valueToAdd = ram.read(finalAddress);
-        if (valueToAdd > (255 - this.a)) 
+
+        auto result = cast(ushort)(a+m+c);
+
+        // Check for overflow
+        if (result > 255) 
         {
-            this.a = cast(ubyte)(valueToAdd - cast(ubyte)(255 - this.a));
+            this.a = cast(ubyte)(result - 255); 
             this.status.c = 1;
         }
         else
         {
-            this.a += valueToAdd;
+            this.a += cast(ubyte)(result);
         }
 
-        if (this.a == 0) this.status.z = 1;
-        // @TODO: How do I set the overflow flag? (v) 
-        if ((this.a & 0b1000_0000) == 0b1000_0000)  this.status.n = 1; 
+        if (this.a == 0) 
+            this.status.z = 1;
+        
+        if ((this.a & 0b1000_0000) == 0b1000_0000) 
+            this.status.n = 1; 
+        
+        if (((this.a^m) & 0x80) == 0 && ((a^this.a) & 0x80) != 0)
+        {
+            this.status.v = 1;
+        }
+        else 
+        {
+            this.status.v = 0;
+        }
+
+        switch (opcode)
+        {
+            case 0x69: // Immediate
+                this.cycle += 2;
+                break;
+            case 0x65: // ZeroPage
+                this.cycle += 3;
+                break;
+            case 0x6D: // Absolute
+            case 0x75: // ZeroPage,X
+                this.cycle += 4;
+            case 0x7D: // Absolute,X
+            case 0x79: // Absolute,Y
+                this.cycle += 4;
+                if (bPageBoundaryCrossed) 
+                    this.cycle++;
+                break;
+            case 0x61: // Indirect,X
+                this.cycle += 6;
+                break;
+            case 0x71: // Indirect,Y
+                this.cycle += 5;
+                if (bPageBoundaryCrossed) 
+                    this.cycle++;
+                break;
+        }
     }
     unittest
     {
@@ -261,7 +312,7 @@ class MOS6502
     //***** Addressing Modes *****//
     // Immediate address mode is the operand is a 1 byte constant following the
     // opcode so read the constant, increment pc by 1 and return it
-    ubyte immediateAddressMode()
+    ushort immediateAddressMode()
     {
         return Console.ram.read(this.pc++);
     }
@@ -298,9 +349,9 @@ class MOS6502
         assert(cpu.pc == 0xC001);
     }
     
-    // zero page index address indicates that byte following the operand is an address
-    // from 0x0000 to 0x00FF (256 bytes). in this case we read in the address 
-    // then offset it by the value in a specified register (X, Y, etc)
+    // zero page index address indicates that byte following the operand is an 
+    // address from 0x0000 to 0x00FF (256 bytes). in this case we read in the 
+    // address then offset it by the value in a specified register (X, Y, etc)
     // when calling this function you must provide the value to be indexed by
     // for example an instruction that is 
     // STY Operand, Y
@@ -517,9 +568,10 @@ class MOS6502
 
     // indirect indexed is similar to indexed indirect, except the index offset
     // is added to the final memory value instead of to the zero page address
-    // so this mode will read a zero page address as the next byte after the operand,
-    // look up a 16 bit value in the zero page, add the index to that and return it
-    // as the final address. note that there is no zero page address wrapping
+    // so this mode will read a zero page address as the next byte after the 
+    // operand, look up a 16 bit value in the zero page, add the index to that 
+    // and return it as the final address. note that there is no zero page 
+    // address wrapping
     ushort indirectIndexedAddressMode(ubyte indexValue)
     {
         ubyte zeroPageAddress = Console.ram.read(this.pc++);


### PR DESCRIPTION
Look, i know we talked about this last night, but I _really really_ think this would be easier if we just had a couple tables linking each opcode to a specific address mode "enum", and  base cycle-count, and we just detect when the page boundaries are crossed within the instruction implementation.

As it is, the code is becoming too switch-statement heavy, and I think it will be prone to lots of bugs. 
